### PR TITLE
Change las_dictionary_tests for os-specific paths

### DIFF
--- a/las_dictionary_test.go
+++ b/las_dictionary_test.go
@@ -4,6 +4,7 @@
 package glasio
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -12,19 +13,19 @@ func TestLoadStdMnemonicDic(t *testing.T) {
 	if err == nil {
 		t.Errorf("<LoadStdMnemonicDic> on test 1 return error == nil\n")
 	}
-	_, err = LoadStdMnemonicDic("data\\mnemonic.ini") //file ini exist, return error == nil
+	_, err = LoadStdMnemonicDic(filepath.Join("data", "mnemonic.ini")) //file ini exist, return error == nil
 	if err != nil {
 		t.Errorf("<LoadStdMnemonicDic> on test 2 expect error = nil, return error: %s\n", err)
 	}
-	_, err = LoadStdMnemonicDic("data\\mn.ini") //file ini not exist, return error
+	_, err = LoadStdMnemonicDic(filepath.Join("data", "mn.ini")) //file ini not exist, return error
 	if err == nil {
 		t.Errorf("<LoadStdMnemonicDic> on test 3 expect error != nil, return nil\n")
 	}
-	_, err = LoadStdMnemonicDic("data\\dic.ini") //file ini exist, section not exist, return error != nil
+	_, err = LoadStdMnemonicDic(filepath.Join("data", "dic.ini")) //file ini exist, section not exist, return error != nil
 	if err == nil {
 		t.Errorf("<LoadStdMnemonicDic> on test 4 expect error = nil, return error: %s\n", err)
 	}
-	_, err = LoadStdMnemonicDic("data\\dic0.ini") //file ini exist, file empty, return error != nil
+	_, err = LoadStdMnemonicDic(filepath.Join("data", "dic0.ini")) //file ini exist, file empty, return error != nil
 	if err == nil {
 		t.Errorf("<LoadStdMnemonicDic> on test 5 expect error = nil, return error: %s\n", err)
 	}
@@ -35,19 +36,19 @@ func TestLoadStdVocabularyDictionary(t *testing.T) {
 	if err == nil {
 		t.Errorf("<LoadStdVocabularyDictionary> on test 1 return error == nil\n")
 	}
-	_, err = LoadStdVocabularyDictionary("data\\dic.ini") //file ini exist, return error == nil
+	_, err = LoadStdVocabularyDictionary(filepath.Join("data", "dic.ini")) //file ini exist, return error == nil
 	if err != nil {
 		t.Errorf("<LoadStdVocabularyDictionary> on test 2 expect error = nil, return error: %s\n", err)
 	}
-	_, err = LoadStdVocabularyDictionary("data\\mn.ini") //file ini not exist, return error
+	_, err = LoadStdVocabularyDictionary(filepath.Join("data", "mn.ini")) //file ini not exist, return error
 	if err == nil {
 		t.Errorf("<LoadStdVocabularyDictionary> on test 3 expect error != nil, return nil\n")
 	}
-	_, err = LoadStdVocabularyDictionary("data\\mnemonic.ini") //file ini exist, section not exist, return error != nil
+	_, err = LoadStdVocabularyDictionary(filepath.Join("data", "mnemonic.ini")) //file ini exist, section not exist, return error != nil
 	if err == nil {
 		t.Errorf("<LoadStdVocabularyDictionary> on test 4 expect error = nil, return error: %s\n", err)
 	}
-	_, err = LoadStdVocabularyDictionary("data\\mnemonic0.ini") //file ini exist, file empty, return error != nil
+	_, err = LoadStdVocabularyDictionary(filepath.Join("data", "mnemonic0.ini")) //file ini exist, file empty, return error != nil
 	if err == nil {
 		t.Errorf("<LoadStdVocabularyDictionary> on test 5 expect error = nil, return error: %s\n", err)
 	}


### PR DESCRIPTION
@softlandia,

This change, enables las_dictionary_test.go to run its tests on different Operating Systems.
It changes the hard-coded file paths to be generated with path/filepath.Join().

The test still pass.  Here is the test-run result:

```bash
$ go test -v -run TestLoadStdMnemonicDic
=== RUN   TestLoadStdMnemonicDic
--- PASS: TestLoadStdMnemonicDic (0.00s)
PASS
ok      github.com/softlandia/glasio    0.016s

$ go test -v -run TestLoadStdVocabularyDictionary
=== RUN   TestLoadStdVocabularyDictionary
--- PASS: TestLoadStdVocabularyDictionary (0.00s)
PASS
ok      github.com/softlandia/glasio    0.016s
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC