### PR TITLE
Try to set missing STRT field to a sensible value

### DIFF
--- a/examples/repaire/main.go
+++ b/examples/repaire/main.go
@@ -13,8 +13,8 @@ import (
 //Пример чтения и сохранения нескольких LAS файлов
 func main() {
 	fileList := make([]string, 0, 10)
-	n := findFilesExt(&fileList, ".\\", ".las")
-	fmt.Printf("files founded: %d\n", n)
+	n := findFilesExt(&fileList, ".", ".las")
+	fmt.Printf("files found: %d\n", n)
 	if n == 0 {
 		os.Exit(0)
 	}
@@ -28,10 +28,10 @@ func repaireLas(fileName string) {
 	las.FileName = fileName
 	fmt.Printf("file: '%s'", fileName)
 	n, err := las.Open(fileName) // считываем файл
-	fmt.Printf(" readed\n")
+	fmt.Printf(" read\n")
 	// примеры проверки прочитанного las файла
 	if las.IsWraped() {
-		fmt.Printf("wraped\n")
+		fmt.Printf("wrapped\n")
 		return
 	}
 	if n == 0 {

--- a/examples/repaire/sample_2.0_missing_strt.las
+++ b/examples/repaire/sample_2.0_missing_strt.las
@@ -1,0 +1,46 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/las.go
+++ b/las.go
@@ -273,6 +273,15 @@ func (las *Las) Open(fileName string) (int, error) {
 	if r.nullWrong() {
 		las.SetNull(las.stdNull)
 	}
+	if r.strtWrong() {
+
+		h := las.GetStrtFromData() // return las.Null if cannot find strt in the data section.
+		if h == las.Null {
+			las.addWarning(TWarning{directOnRead, lasSecWellInfo, -1, fmt.Sprint("__WRN__ STRT parameter on data is wrong setting to 0")})
+			las.setStrt(0)
+		}
+		las.setStrt(h)
+	}
 	if r.stepWrong() {
 		h := las.GetStepFromData() // return las.Null if cannot calculate step from data
 		if h == las.Null {
@@ -312,7 +321,7 @@ func (las *Las) LoadHeader() error {
 		if s[0] == '~' { //start new section
 			secNum = las.selectSection(rune(s[1]))
 			if secNum == lasSecData {
-				break // dAta section read after //exit from for
+				break // data section read after //exit from for
 			}
 		} else {
 			//if not comment, not empty and not new section => parameter, read it
@@ -536,7 +545,7 @@ func (las *Las) ReadDataSec(fileName string) (int, error) {
 			iSpace := strings.IndexFunc(s, isSeparator)
 			switch iSpace {
 			case -1: //не все колонки прочитаны, а разделителей уже нет... пробуем игнорировать сроку заполняя оставшиеся каротажи NULLами
-				las.addWarning(TWarning{directOnRead, lasSecData, las.currentLine, "not all column readed, set log value to NULL"})
+				las.addWarning(TWarning{directOnRead, lasSecData, las.currentLine, "not all column are read, set log value to NULL"})
 			case 0:
 				v = las.Null
 			case 1:
@@ -560,7 +569,7 @@ func (las *Las) ReadDataSec(fileName string) (int, error) {
 		//остаток - последняя колонка
 		v, err = strconv.ParseFloat(s, 64)
 		if err != nil {
-			las.addWarning(TWarning{directOnRead, lasSecData, las.currentLine, "not all column readed, set log value to NULL"})
+			las.addWarning(TWarning{directOnRead, lasSecData, las.currentLine, "not all column are read, set log value to NULL"})
 			v = las.Null
 		}
 		l, err = las.logByIndex(n - 1)
@@ -705,6 +714,45 @@ func (las *Las) IsEmpty() bool {
 	return (las.Logs == nil)
 }
 
+// GetStrtFromData - return strt from data section
+// read 1 line from section ~A and determine strt
+// close file
+// return Null if error occurs
+// если делать функцией, не методом, то придётся NULL передавать. а оно надо вообще
+func (las *Las) GetStrtFromData() float64 {
+	iFile, err := os.Open(las.FileName)
+	if err != nil {
+		return las.Null
+	}
+	defer iFile.Close()
+
+	_, iScanner, err := xlib.SeekFileStop(las.FileName, "~A")
+	if (err != nil) || (iScanner == nil) {
+		return las.Null
+	}
+
+	s := ""
+	dept1 := 0.0
+	for i := 0; iScanner.Scan(); i++ {
+		s = strings.TrimSpace(iScanner.Text())
+		if (len(s) == 0) || (s[0] == '#') {
+			continue
+		}
+		k := strings.IndexRune(s, ' ')
+		if k < 0 {
+			k = len(s)
+		}
+		dept1, err = strconv.ParseFloat(s[:k], 64)
+		if err != nil {
+			return las.Null
+		}
+		return dept1
+	}
+	//если мы попали сюда, то всё грусно, в файле после ~A не нашлось двух строчек с данными... или пустые строчки или комменты
+	// TODO последняя строка "return las.Null" не обрабатывается в тесте
+	return las.Null
+}
+
 // GetStepFromData - return step from data section
 // read 2 line from section ~A and determine step
 // close file
@@ -752,6 +800,10 @@ func (las *Las) GetStepFromData() float64 {
 
 func (las *Las) setStep(h float64) {
 	las.Step = h
+}
+
+func (las *Las) setStrt(h float64) {
+	las.Strt = h
 }
 
 // IsStrtEmpty - return true if parameter Strt not exist in file

--- a/las_checker.go
+++ b/las_checker.go
@@ -55,6 +55,11 @@ func (crs CheckResults) curvesWrong() bool {
 	return ok
 }
 
+func (crs CheckResults) strtWrong() bool {
+	_, ok := crs["STRT"]
+	return ok
+}
+
 func (crs CheckResults) strtStopWrong() bool {
 	_, ok := crs["SSTP"]
 	return ok

--- a/las_summary_test.go
+++ b/las_summary_test.go
@@ -26,7 +26,7 @@ type tSummaryCheck struct {
 }
 
 var dSummaryCheck = []tSummaryCheck{
-	{fp.Join("data/barebones.las"), 2.0, "NO", -999.25, -999.25, 1.1, -999.25, "", 1, 0, true},
+	{fp.Join("data/barebones.las"), 2.0, "NO", 200, -999.25, 1.1, -999.25, "", 1, 0, true},
 	{fp.Join("data/6038187_v1.2.las"), 2.0, "NO", 0.05, 136.6, 0.05, -99999, "Scorpio E1", 9, 2732, false},
 	{fp.Join("data/6038187_v1.2_short.las"), 2.0, "NO", 0.05, 136.6, 0.05, -99999, "Scorpio E1", 9, 121, false},
 	{fp.Join("data/1001178549.las"), 2.0, "YES", 1783.5, 1784.5, 0.25, -999.25, "1-28", 27, 0, true},

--- a/las_test.go
+++ b/las_test.go
@@ -163,6 +163,24 @@ func TestLasSaveWarning(t *testing.T) {
 	assert.Equal(t, 21, n)
 }
 
+type tGetDataStrt struct {
+	fn string
+	st float64
+}
+
+var dGetDataStrt = []tGetDataStrt{
+	{fp.Join("data/2.0/sample_2.0_missing_strt.las"), 1670.000},
+	{fp.Join("data/2.0/sample_2.0.las"), 1670.000},
+}
+
+func TestGetStrtFromData(t *testing.T) {
+	for _, tmp := range dGetDataStrt {
+		las := NewLas()
+		las.Open(tmp.fn)
+		assert.Equal(t, tmp.st, las.Strt, fmt.Sprintf("<TestGetStepFromData> fail on file '%s' \n", tmp.fn))
+	}
+}
+
 type tGetDataStep struct {
 	fn string
 	st float64


### PR DESCRIPTION
This pull request attempts to be solution for issue #7 `If las file is missing STRT then after read las must have STRT = first point of DEPT, but = 0`

It includes:
- a new func GetStrtFromData().  
- a new test in las_test.go: TestGetStrtFromData()
- a new test file with a missing STRT value based on the standard sample_2.0.las file

All test pass.

Notes:
- GetStrtFromData() is mostly a copy of GetStepFromData().   A future improvement would be to combine them so that we only open the file once to get the data.  

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC



